### PR TITLE
Fix Typescript default exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-module.exports = {
+var exports = {
     it: require("./lib/theoretically.it.js"),
-    xit: require("./lib/theoretically.xit.js"),
-    default: {
-        it: require("./lib/theoretically.it.js"),
-        xit: require("./lib/theoretically.xit.js")
-    }
+    xit: require("./lib/theoretically.xit.js")
 };
+
+exports.default = exports;
+module.exports = exports;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 module.exports = {
     it: require("./lib/theoretically.it.js"),
-    xit: require("./lib/theoretically.xit.js")
+    xit: require("./lib/theoretically.xit.js"),
+    default: {
+        it: require("./lib/theoretically.it.js"),
+        xit: require("./lib/theoretically.xit.js")
+    }
 };


### PR DESCRIPTION
according to http://2ality.com/2014/09/es6-modules-final.html#default-exports-one-per-module the correct way to export would be to export an item called default.
WIthoiut this extra item it is working fine in karma. In wallabyjs it is failing miserably, ignoring every theory test. With this change it works again.