### PR TITLE
Added IDE code completion support for the done.fail() invocation.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,16 @@
 declare namespace jasmineTheories {
+	/**
+	 * Action method that should be called when the async work is complete.
+	 */
+	interface DoneFn extends Function {
+		(): void;
+
+		/** fails the spec and indicates that it has completed. If the message is an Error, Error.message is used */
+		fail: (message?: Error | string) => void;
+	}
+
+	type ImplementationCallback = ((testedValue: any) => PromiseLike<any>) | ((testedValue: any, done: DoneFn) => void);
+
 	interface jasmineTheoriesStatic {
 		/**
 		 * Runs the jasmine test function with each of the given arguments
@@ -6,15 +18,15 @@ declare namespace jasmineTheories {
 		 * @param args argunments passed to the test
 		 * @param testFunction the test
 		 */
-		it(description: string, args: any[], testFunction: (testedValue: any, done?: () => void) => void): void;
- 
+		it(description: string, args: any[], testFunction: ImplementationCallback): void;
+
 		/**
 		 * Ignored version of the "it" test (the x means excluded)
 		 * @param description the description of the test
 		 * @param args argunments passed to the test
 		 * @param testFunction the test
 		 */
-		xit(description: string, args: any[], testFunction: (testedValue: any, done?: () => void) => void): void;
+		xit(description: string, args: any[], testFunction: ImplementationCallback): void;
 	}
  }
  declare var jsminTheories: jasmineTheories.jasmineTheoriesStatic;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-theories",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Lets you run the same spec with varying input. Like theories in XUnit.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Hi @hypesystem!
I've made one small improvement because currently, my IDE (Rider) makes me add the "@ts-ignore" hint not to get the incorrect syntax error. Feel free to suggest improvements to my solution.
Thanks!